### PR TITLE
Add Draft Super option to launcher 

### DIFF
--- a/Launcher/MainWindow.xaml
+++ b/Launcher/MainWindow.xaml
@@ -43,6 +43,7 @@
                                 <ComboBoxItem Content="Draft low"/>
                                 <ComboBoxItem Content="Draft medium"/>
                                 <ComboBoxItem Content="Draft high"/>
+                                <ComboBoxItem Content="Draft super"/>
                                 <ComboBoxItem Content="Low"/>
                                 <ComboBoxItem Content="Medium"/>
                                 <ComboBoxItem Content="High"/>
@@ -147,8 +148,8 @@
                 <TabItem Header="Settings" Margin="-2,-3,2,3" Width="105" Height="24">
                     <Grid Background="#FFE5E5E5">
                         <Button Content="Reset Sapien window layout" Margin="32,10,152,0" VerticalAlignment="Top" Click="ResetSapienDisplay" RenderTransformOrigin="0.509,0.65"/>
-                        <CheckBox x:Name="large_addr_enabled" Content="Use executables with large address support" HorizontalAlignment="Left" Margin="32,35,0,0" VerticalAlignment="Top" Width="265" HorizontalContentAlignment="Center" Checked="large_addr_enabled_Checked" Unchecked="large_addr_enabled_Checked"/>
-                        <CheckBox x:Name="ignore_updates_enabled" Content="Ignore Updates" HorizontalAlignment="Left" Margin="32,55,0,0" VerticalAlignment="Top" Width="265" HorizontalContentAlignment="Center" Checked="ignore_updates_enabled_Checked" Unchecked="ignore_updates_enabled_Checked"/>
+                        <CheckBox x:Name="large_addr_enabled" Content="Use executables with large address support" HorizontalAlignment="Left" Margin="32,35,0,0" VerticalAlignment="Top" Width="265" Checked="large_addr_enabled_Checked" Unchecked="large_addr_enabled_Checked"/>
+                        <CheckBox x:Name="ignore_updates_enabled" Content="Ignore Updates" HorizontalAlignment="Left" Margin="32,55,0,0" VerticalAlignment="Top" Width="265" Checked="ignore_updates_enabled_Checked" Unchecked="ignore_updates_enabled_Checked"/>
                     </Grid>
                 </TabItem>
                 <TabItem Header="Credits" Margin="-2,-3,2,3" Width="105" Height="24">

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -55,6 +55,7 @@ namespace Halo2CodezLauncher
             draft_low,
             draft_medium,
             draft_high,
+            draft_super,
             low,
             medium,
             high,


### PR DESCRIPTION
Added the option in the launcher to use draft super when lighting a map (why isn't it there?) and some minor visual fixups to the launcher.