### PR TITLE
Fixed an issue with paths

### DIFF
--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -750,14 +750,14 @@ namespace Halo2CodezLauncher
                     if (render_type == 0)
                     {
                         process.FileName = GetToolExeName(tool_type.tool);
-                        process.Arguments = "model-render \"" + path + "\"";
+                        process.Arguments = "model-render \"" + path.Replace(H2Ek_install_path + "data\\", "") + "\"";
                         process.Arguments += " pause_after_run";
                         RunProcess(process, true);
                     }
                     else
                     {
                         process.FileName = GetToolExeName(tool_type.daeconverter);
-                        process.Arguments = "-compile " + "data\\" + path.Replace(H2Ek_install_path + "data\\", "");
+                        process.Arguments = "-compile \"" + path.Replace(H2Ek_install_path, "") + "\"";
                         process.Arguments += " pause_after_run";
                         RunProcess(process, true);
                     }


### PR DESCRIPTION
Changed how to the path gets set for the model-render command to avoid an issue with it not finding the shader collections file. This will cause an issue where the BSP converter command will run twice if there is an identical path in documents.

Added quotes to the DAE compile path.