### PR TITLE
Various fixes to launcher issues and new features.

### DIFF
--- a/Launcher/App.config
+++ b/Launcher/App.config
@@ -21,7 +21,10 @@
             </setting>
             <setting name="ignore_updates" serializeAs="String">
                 <value>False</value>
-            </setting>        
+            </setting>
+            <setting name="portable_install" serializeAs="String">
+                <value>False</value>
+            </setting>
         </H2CodezLauncher.Properties.Settings>
     </userSettings>
     <applicationSettings>

--- a/Launcher/MainWindow.xaml
+++ b/Launcher/MainWindow.xaml
@@ -138,11 +138,11 @@
                         <Button x:Name="browse_ltf" Content="Browse" HorizontalAlignment="Left" Margin="10,53,0,0" VerticalAlignment="Top" Width="75" RenderTransformOrigin="0.253,0.45" Click="browse_ltf_Click"/>
                         <Button x:Name="import_lipsync" Content="Import Sound" HorizontalAlignment="Left" Margin="10,156,0,0" VerticalAlignment="Top" Width="325" RenderTransformOrigin="-0.2,0.35" Click="import_sound_Click"/>
 
-                        <TextBlock HorizontalAlignment="Left" Height="23" Margin="103,22,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="235" RenderTransformOrigin="0.249,0.696" Text="Select sound to add lipsync data to." Foreground="{StaticResource brushWatermarkForeground}" 
+                        <TextBlock HorizontalAlignment="Left" Height="23" Margin="103,22,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="235" RenderTransformOrigin="0.249,0.696" Text="Select .WAV or .AIFF file" Foreground="{StaticResource brushWatermarkForeground}" 
                        Visibility="{Binding ElementName=import_sound_path, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}"  FontStyle="Italic"/>
                         <TextBox Name="import_sound_path" BorderBrush="{StaticResource brushWatermarkBorder}" HorizontalAlignment="Left" Height="23" Margin="100,20,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="235" Background="Transparent" RenderTransformOrigin="0.249,0.696"/>
 
-                        <TextBlock HorizontalAlignment="Left" Height="23" Margin="103,52,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="235" RenderTransformOrigin="0.249,0.696" Text="Select ltf to generate lipsync data from." Foreground="{StaticResource brushWatermarkForeground}" 
+                        <TextBlock HorizontalAlignment="Left" Height="23" Margin="103,52,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="235" RenderTransformOrigin="0.249,0.696" Text="Select .LTF file" Foreground="{StaticResource brushWatermarkForeground}" 
                        Visibility="{Binding ElementName=import_lipsync_path, Path=Text.IsEmpty, Converter={StaticResource BooleanToVisibilityConverter}}"  FontStyle="Italic"/>
                         <TextBox Name="import_lipsync_path" BorderBrush="{StaticResource brushWatermarkBorder}" HorizontalAlignment="Left" Height="23" Margin="100,50,0,0" TextWrapping="Wrap" VerticalAlignment="Top" Width="235" Background="Transparent" RenderTransformOrigin="0.249,0.696"/>
                     </Grid>

--- a/Launcher/MainWindow.xaml
+++ b/Launcher/MainWindow.xaml
@@ -166,6 +166,7 @@
                         <Button Content="Repair registry" Margin="32,40,152,0" VerticalAlignment="Top" Click="RepairRegistry" RenderTransformOrigin="0.509,0.65"/>
                         <CheckBox x:Name="large_addr_enabled" Content="Use executables with large address support" HorizontalAlignment="Left" Margin="32,65,0,0" VerticalAlignment="Top" Width="265" Checked="large_addr_enabled_Checked" Unchecked="large_addr_enabled_Checked"/>
                         <CheckBox x:Name="ignore_updates_enabled" Content="Ignore Updates" HorizontalAlignment="Left" Margin="32,85,0,0" VerticalAlignment="Top" Width="265" Checked="ignore_updates_enabled_Checked" Unchecked="ignore_updates_enabled_Checked"/>
+                        <CheckBox x:Name="portable_install_enabled" Content="Portable Install" HorizontalAlignment="Left" Margin="32,105,0,0" VerticalAlignment="Top" Width="265" Checked="portable_install_enabled_checked" Unchecked="portable_install_enabled_checked"/>
                     </Grid>
                 </TabItem>
                 <TabItem Header="Credits" Margin="-2,-3,2,3" Width="105" Height="24">

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -221,7 +221,7 @@ namespace Halo2CodezLauncher
         {
             string H2Tool_Path = AppDomain.CurrentDomain.BaseDirectory;
 
-            if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair is true)
+            if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair is true && Settings.Default.portable_install != true)
             {
                 RegistryKey H2EK_Install_Path_key = RegistryKey
                     .OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
@@ -231,14 +231,7 @@ namespace Halo2CodezLauncher
                     .OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
                     .CreateSubKey("SOFTWARE\\Microsoft\\Halo 2", true);
 
-                if (force_repair == true)
-                {
-                    MessageBox.Show("Please select H2Tool.exe");
-                }
-                else
-                {
-                    MessageBox.Show("Missing Halo 2 Editing Kit related registry keys. Please select H2Tool.exe");
-                }
+                MessageBox.Show("Please select H2Tool.exe");
 
                 OpenFileDialog dlg = new OpenFileDialog();
                 dlg.Title = "Selet H2Tool.exe";
@@ -256,7 +249,7 @@ namespace Halo2CodezLauncher
 
                 H2Ek_install_path = new FileInfo(H2Tool_Path).Directory.FullName;
 
-                if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair == true && use_launcher_path == false)
+                if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair == true && use_launcher_path != true)
                 {
                     H2EK_Install_Path_key.SetValue("ToolsInstallDir", H2Ek_install_path + "\\");
                     H2EK_Install_Path_key.Close();
@@ -277,6 +270,7 @@ namespace Halo2CodezLauncher
             InitializeComponent();
             large_addr_enabled.IsChecked = Settings.Default.large_address_support;
             ignore_updates_enabled.IsChecked = Settings.Default.ignore_updates;
+            portable_install_enabled.IsChecked = Settings.Default.portable_install;
             // Delete any left over update files.
             try
             {
@@ -293,9 +287,23 @@ namespace Halo2CodezLauncher
                 Thread.CurrentThread.IsBackground = true;
                 try
                 {
-                    repair_registry(false, false);
+                    if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null && Settings.Default.portable_install != true)
+                    {
+                        if (MessageBox.Show("Is this a portable install?", "Missing Registry Keys", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                        {
+                            MessageBox.Show("Using launcher path as install location. Please ensure it is inside of your map editor folder.", "Portable Install Confirmed");
+                            Settings.Default.portable_install = true;
+                            Settings.Default.Save();
+                        }
+                        else
+                        {
+                            repair_registry(false, false);
+                        }
 
-                    if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null)
+                    }
+
+
+                    if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null && Settings.Default.portable_install == true)
                     {
                         H2Ek_install_path = new FileInfo(Launcher_Directory).Directory.FullName;
                     }
@@ -954,9 +962,16 @@ namespace Halo2CodezLauncher
             Settings.Default.large_address_support = (bool)large_addr_enabled.IsChecked;
             Settings.Default.Save();
         }
+
         private void ignore_updates_enabled_Checked(object sender, RoutedEventArgs e)
         {
             Settings.Default.ignore_updates = (bool)ignore_updates_enabled.IsChecked;
+            Settings.Default.Save();
+        }
+
+        private void portable_install_enabled_checked(object sender, RoutedEventArgs e)
+        {
+            Settings.Default.portable_install = (bool)portable_install_enabled.IsChecked;
             Settings.Default.Save();
         }
 

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -302,7 +302,6 @@ namespace Halo2CodezLauncher
 
                     }
 
-
                     if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null && Settings.Default.portable_install == true)
                     {
                         H2Ek_install_path = new FileInfo(Launcher_Directory).Directory.FullName;

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -161,9 +161,8 @@ namespace Halo2CodezLauncher
                     name = "";
                     break;
             }
-            if (type != tool_type.guerilla && Settings.Default.large_address_support)
-                if (type != tool_type.daeconverter && Settings.Default.large_address_support)
-                    name += ".large_address";
+            if (type != tool_type.guerilla && type != tool_type.daeconverter && Settings.Default.large_address_support)
+                name += ".large_address";
             return name + ".exe";
         }
 
@@ -918,7 +917,7 @@ namespace Halo2CodezLauncher
                 RunProcess(process);
             }
 
-            if (!string.IsNullOrWhiteSpace(import_sound_path.Text) && !string.IsNullOrWhiteSpace(import_lipsync_path.Text))
+            else if (!string.IsNullOrWhiteSpace(import_sound_path.Text) && !string.IsNullOrWhiteSpace(import_lipsync_path.Text))
             {
                 string sound_path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(import_sound_path.Text));
                 string ltf_path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(import_lipsync_path.Text), System.IO.Path.GetFileNameWithoutExtension(import_lipsync_path.Text));
@@ -929,6 +928,14 @@ namespace Halo2CodezLauncher
                 process.Arguments = "import-lipsync \"" + sound_path + "\" " + "\"" + ltf_path + "\"";
                 process.Arguments += " pause_after_run";
                 RunProcess(process);
+            }
+            else if (string.IsNullOrWhiteSpace(import_sound_path.Text) && !string.IsNullOrWhiteSpace(import_lipsync_path.Text))
+            {
+                MessageBox.Show("Error: No file path in sound textbox!");
+            }
+            else if (string.IsNullOrWhiteSpace(import_sound_path.Text) && string.IsNullOrWhiteSpace(import_lipsync_path.Text))
+            {
+                MessageBox.Show("Error: No file path in sound textbox or ltf textbox!");
             }
         }
 

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -218,7 +218,7 @@ namespace Halo2CodezLauncher
         void repair_registry(bool force_repair, bool use_launcher_path)
         {
             string H2Tool_Path = AppDomain.CurrentDomain.BaseDirectory;
-            if (Settings.Default.portable_install != true)
+            if (Settings.Default.portable_install != true || force_repair is true)
             {
                 if (Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair is true)
                 {
@@ -254,11 +254,17 @@ namespace Halo2CodezLauncher
                         }
                         force_repair = false;
                     }
+
+                    if (Settings.Default.portable_install == true)
+                    {
+                        Settings.Default.portable_install = false;
+                        Settings.Default.Save();
+                        this.Dispatcher.Invoke(() =>
+                        {
+                            portable_install_enabled.IsChecked = Settings.Default.portable_install;
+                        });
+                    }
                 }
-            }
-            else
-            {
-                MessageBox.Show("Portable install enabled. Please disable first.");
             }
         }
 

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -744,7 +744,15 @@ namespace Halo2CodezLauncher
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select Uncompiled level";
             dlg.Filter = "Uncompiled map geometry|*.ASS;*.JMS";
-            dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            if(string.IsNullOrWhiteSpace(compile_level_path.Text))
+            {
+                dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            }
+            else
+            {
+                dlg.InitialDirectory = compile_level_path.Text;
+            }
+
             if (dlg.ShowDialog() == true)
             {
                 compile_level_path.Text = dlg.FileName;
@@ -756,7 +764,15 @@ namespace Halo2CodezLauncher
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select unicode encoded .txt file to compile.";
             dlg.Filter = "Unicode encoded .txt files|*.txt";
-            dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            if (string.IsNullOrWhiteSpace(compile_text_path.Text))
+            {
+                dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            }
+            else
+            {
+                dlg.InitialDirectory = compile_text_path.Text;
+            }
+
             if (dlg.ShowDialog() == true)
             {
                 compile_text_path.Text = dlg.FileName;
@@ -768,7 +784,15 @@ namespace Halo2CodezLauncher
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select Image File";
             dlg.Filter = "Supported image files|*.tif;*.tga;*.jpg;*.bmp";
-            dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            if (string.IsNullOrWhiteSpace(compile_image_path.Text))
+            {
+                dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            }
+            else
+            {
+                dlg.InitialDirectory = compile_image_path.Text;
+            }
+
             if (dlg.ShowDialog() == true)
             {
                 compile_image_path.Text = dlg.FileName;
@@ -780,7 +804,15 @@ namespace Halo2CodezLauncher
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select Scenario";
             dlg.Filter = "Unpackaged Map|*.scenario";
-            dlg.InitialDirectory = H2Ek_install_path +"tags\\";
+            if (string.IsNullOrWhiteSpace(package_level_path.Text))
+            {
+                dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            }
+            else
+            {
+                dlg.InitialDirectory = package_level_path.Text;
+            }
+
             if (dlg.ShowDialog() == true)
             {
                 package_level_path.Text = dlg.FileName;
@@ -906,7 +938,14 @@ namespace Halo2CodezLauncher
             dlg.EnsurePathExists = true;
             dlg.Multiselect = false;
             dlg.ShowPlacesList = true;
-            dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            if (string.IsNullOrWhiteSpace(compile_model_path.Text))
+            {
+                dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            }
+            else
+            {
+                dlg.InitialDirectory = compile_model_path.Text;
+            }
 
             if (dlg.ShowDialog() == CommonFileDialogResult.Ok)
             {
@@ -986,7 +1025,14 @@ namespace Halo2CodezLauncher
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select sound file.";
             dlg.Filter = "Halo Sound Tag|*.sound";
-            dlg.InitialDirectory = H2Ek_install_path + "tags\\";
+            if (string.IsNullOrWhiteSpace(import_sound_path.Text))
+            {
+                dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            }
+            else
+            {
+                dlg.InitialDirectory = import_sound_path.Text;
+            }
 
             if (dlg.ShowDialog() == true)
             {
@@ -1000,7 +1046,14 @@ namespace Halo2CodezLauncher
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select ltf file.";
             dlg.Filter = "Lipsync Tweak File|*.ltf";
-            dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            if (string.IsNullOrWhiteSpace(import_lipsync_path.Text))
+            {
+                dlg.InitialDirectory = H2Ek_install_path + "data\\";
+            }
+            else
+            {
+                dlg.InitialDirectory = import_lipsync_path.Text;
+            }
 
             if (dlg.ShowDialog() == true)
             {

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -161,8 +161,9 @@ namespace Halo2CodezLauncher
                     name = "";
                     break;
             }
-            if (type != tool_type.daeconverter || type != tool_type.guerilla && Settings.Default.large_address_support)
-                name += ".large_address";
+            if (type != tool_type.guerilla && Settings.Default.large_address_support)
+                if (type != tool_type.daeconverter && Settings.Default.large_address_support)
+                    name += ".large_address";
             return name + ".exe";
         }
 

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -161,8 +161,7 @@ namespace Halo2CodezLauncher
                     name = "";
                     break;
             }
-            if (type !=  tool_type.guerilla && Settings.Default.large_address_support)
-                if (type != tool_type.daeconverter && Settings.Default.large_address_support)
+            if (type != tool_type.daeconverter || type != tool_type.guerilla && Settings.Default.large_address_support)
                     name += ".large_address";
             return name + ".exe";
         }

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -162,7 +162,7 @@ namespace Halo2CodezLauncher
                     break;
             }
             if (type != tool_type.daeconverter || type != tool_type.guerilla && Settings.Default.large_address_support)
-                    name += ".large_address";
+                name += ".large_address";
             return name + ".exe";
         }
 

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -289,6 +289,7 @@ namespace Halo2CodezLauncher
 
             new Thread(delegate ()
             {
+                Thread.CurrentThread.IsBackground = true;
                 try
                 {
                     repair_registry(false, false);
@@ -545,14 +546,18 @@ namespace Halo2CodezLauncher
 
         private void RepairRegistry(object sender, RoutedEventArgs e)
         {
-            try
+            new Thread(delegate ()
             {
-                repair_registry(true, false);
-            }
-            catch (UnauthorizedAccessException)
-            {
-                RelaunchAsAdmin("");
-            }
+                Thread.CurrentThread.IsBackground = true;
+                try
+                {
+                    repair_registry(true, false);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    RelaunchAsAdmin("");
+                }
+            }).Start();
         }
 
         private void HandleClickCompile(object sender, RoutedEventArgs e)

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Windows.Threading;
 using PETools;
+using System.Text.RegularExpressions;
 
 namespace Halo2CodezLauncher
 {
@@ -160,8 +161,9 @@ namespace Halo2CodezLauncher
                     name = "";
                     break;
             }
-            if (type != tool_type.guerilla && Settings.Default.large_address_support)
-                name += ".large_address";
+            if (type !=  tool_type.guerilla && Settings.Default.large_address_support)
+                if (type != tool_type.daeconverter && Settings.Default.large_address_support)
+                    name += ".large_address";
             return name + ".exe";
         }
 
@@ -696,7 +698,8 @@ namespace Halo2CodezLauncher
                     map_name = map_name.Replace(".scenario", ".map");
 
                     string copy_to = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\\My Games\\Halo 2\\Maps\\" + map_name;
-                    string copy_from = H2Ek_install_path + "Maps\\" + map_name;
+                    String[] tags_path = Regex.Split(level_path, "tags");
+                    string copy_from = tags_path[0] + "Maps\\" + map_name;
                     try
                     {
                         File.Delete(copy_to);

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -903,22 +903,31 @@ namespace Halo2CodezLauncher
 
         private void import_sound_Click(object sender, RoutedEventArgs e)
         {
-            string sound_path_text = import_sound_path.Text;
-            string ltf_path_text = import_lipsync_path.Text;
-            if (File.Exists(sound_path_text) && File.Exists(ltf_path_text))
+            /* For the future person looking through this. I hail you modder, curious onlooker, 343 employee, whomever. You may see this and be interested in trying it out for yourself.
+               Due to the nature of the code in H2Codez any sound files you try to compile must be in documents and should not be given a filename for reasons.
+               They also can't be given the path that comes  before the tags directory. Good fortune in your hunt*/
+            if (!string.IsNullOrWhiteSpace(import_sound_path.Text) && string.IsNullOrWhiteSpace(import_lipsync_path.Text))
             {
-                string sound_path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(sound_path_text), System.IO.Path.GetFileNameWithoutExtension(sound_path_text));
-                string ltf_path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(ltf_path_text),System.IO.Path.GetFileNameWithoutExtension(ltf_path_text));
+                string sound_path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(import_sound_path.Text).Replace(H2Ek_install_path + "data\\", ""));
+                var process = new ProcessStartInfo();
+                process.WorkingDirectory = H2Ek_install_path;
+                process.FileName = GetToolExeName(tool_type.tool);
+                process.Arguments = "import-sound \"" + sound_path + "\"";
+                process.Arguments += " pause_after_run";
+                RunProcess(process);
+            }
+
+            if (!string.IsNullOrWhiteSpace(import_sound_path.Text) && !string.IsNullOrWhiteSpace(import_lipsync_path.Text))
+            {
+                string sound_path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(import_sound_path.Text));
+                string ltf_path = System.IO.Path.Combine(System.IO.Path.GetDirectoryName(import_lipsync_path.Text), System.IO.Path.GetFileNameWithoutExtension(import_lipsync_path.Text));
+                sound_path = sound_path.Replace("\\data\\", "\\tags\\");
                 var process = new ProcessStartInfo();
                 process.WorkingDirectory = H2Ek_install_path;
                 process.FileName = GetToolExeName(tool_type.tool);
                 process.Arguments = "import-lipsync \"" + sound_path + "\" " + "\"" + ltf_path + "\"";
                 process.Arguments += " pause_after_run";
                 RunProcess(process);
-            }
-            else
-            {
-                MessageBox.Show("Error: No such file!");
             }
         }
 
@@ -1022,8 +1031,8 @@ namespace Halo2CodezLauncher
             }
 
             OpenFileDialog dlg = new OpenFileDialog();
-            dlg.Title = "Select sound file.";
-            dlg.Filter = "Halo Sound Tag|*.sound";
+            dlg.Title = "Select sound file";
+            dlg.Filter = "Sound File|*.AIFF;*.WAV";
             dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == true)

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -798,7 +798,7 @@ namespace Halo2CodezLauncher
 
         private void browse_package_level_Click(object sender, RoutedEventArgs e)
         {
-            string path = H2Ek_install_path + "data\\";
+            string path = H2Ek_install_path + "tags\\";
             if (!string.IsNullOrWhiteSpace(package_level_path.Text))
             {
                 path = System.IO.Path.GetDirectoryName(package_level_path.Text) + "\\";

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -741,17 +741,16 @@ namespace Halo2CodezLauncher
 
         private void browse_level_compile_Click(object sender, RoutedEventArgs e)
         {
+            string path = H2Ek_install_path + "data\\";
+            if (!string.IsNullOrWhiteSpace(compile_level_path.Text))
+            {
+                path = System.IO.Path.GetDirectoryName(compile_level_path.Text) + "\\";
+            }
+
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select Uncompiled level";
             dlg.Filter = "Uncompiled map geometry|*.ASS;*.JMS";
-            if(string.IsNullOrWhiteSpace(compile_level_path.Text))
-            {
-                dlg.InitialDirectory = H2Ek_install_path + "data\\";
-            }
-            else
-            {
-                dlg.InitialDirectory = compile_level_path.Text;
-            }
+            dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == true)
             {
@@ -761,17 +760,16 @@ namespace Halo2CodezLauncher
 
         private void Browse_text_Click(object sender, RoutedEventArgs e)
         {
+            string path = H2Ek_install_path + "data\\";
+            if (!string.IsNullOrWhiteSpace(compile_text_path.Text))
+            {
+                path = System.IO.Path.GetDirectoryName(compile_text_path.Text) + "\\";
+            }
+
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select unicode encoded .txt file to compile.";
             dlg.Filter = "Unicode encoded .txt files|*.txt";
-            if (string.IsNullOrWhiteSpace(compile_text_path.Text))
-            {
-                dlg.InitialDirectory = H2Ek_install_path + "data\\";
-            }
-            else
-            {
-                dlg.InitialDirectory = compile_text_path.Text;
-            }
+            dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == true)
             {
@@ -781,17 +779,16 @@ namespace Halo2CodezLauncher
 
         private void browse_bitmap_Click(object sender, RoutedEventArgs e)
         {
+            string path = H2Ek_install_path + "data\\";
+            if (!string.IsNullOrWhiteSpace(compile_image_path.Text))
+            {
+                path = System.IO.Path.GetDirectoryName(compile_image_path.Text) + "\\";
+            }
+
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select Image File";
             dlg.Filter = "Supported image files|*.tif;*.tga;*.jpg;*.bmp";
-            if (string.IsNullOrWhiteSpace(compile_image_path.Text))
-            {
-                dlg.InitialDirectory = H2Ek_install_path + "data\\";
-            }
-            else
-            {
-                dlg.InitialDirectory = compile_image_path.Text;
-            }
+            dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == true)
             {
@@ -801,17 +798,16 @@ namespace Halo2CodezLauncher
 
         private void browse_package_level_Click(object sender, RoutedEventArgs e)
         {
+            string path = H2Ek_install_path + "data\\";
+            if (!string.IsNullOrWhiteSpace(package_level_path.Text))
+            {
+                path = System.IO.Path.GetDirectoryName(package_level_path.Text) + "\\";
+            }
+
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select Scenario";
             dlg.Filter = "Unpackaged Map|*.scenario";
-            if (string.IsNullOrWhiteSpace(package_level_path.Text))
-            {
-                dlg.InitialDirectory = H2Ek_install_path + "data\\";
-            }
-            else
-            {
-                dlg.InitialDirectory = package_level_path.Text;
-            }
+            dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == true)
             {
@@ -928,6 +924,11 @@ namespace Halo2CodezLauncher
 
         private void browse_model_Click(object sender, RoutedEventArgs e)
         {
+            string path = H2Ek_install_path + "data\\";
+            if (!string.IsNullOrWhiteSpace(compile_model_path.Text))
+            {
+                path = System.IO.Path.GetFileName(compile_model_path.Text) + "\\";
+            }
 
             var dlg = new CommonOpenFileDialog();
             dlg.Title = "Select model folder.";
@@ -938,14 +939,7 @@ namespace Halo2CodezLauncher
             dlg.EnsurePathExists = true;
             dlg.Multiselect = false;
             dlg.ShowPlacesList = true;
-            if (string.IsNullOrWhiteSpace(compile_model_path.Text))
-            {
-                dlg.InitialDirectory = H2Ek_install_path + "data\\";
-            }
-            else
-            {
-                dlg.InitialDirectory = compile_model_path.Text;
-            }
+            dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == CommonFileDialogResult.Ok)
             {
@@ -1021,18 +1015,16 @@ namespace Halo2CodezLauncher
 
         private void browse_sound_Click(object sender, RoutedEventArgs e)
         {
+            string path = H2Ek_install_path + "data\\";
+            if (!string.IsNullOrWhiteSpace(import_sound_path.Text))
+            {
+                path = System.IO.Path.GetDirectoryName(import_sound_path.Text) + "\\";
+            }
 
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select sound file.";
             dlg.Filter = "Halo Sound Tag|*.sound";
-            if (string.IsNullOrWhiteSpace(import_sound_path.Text))
-            {
-                dlg.InitialDirectory = H2Ek_install_path + "data\\";
-            }
-            else
-            {
-                dlg.InitialDirectory = import_sound_path.Text;
-            }
+            dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == true)
             {
@@ -1042,18 +1034,16 @@ namespace Halo2CodezLauncher
 
         private void browse_ltf_Click(object sender, RoutedEventArgs e)
         {
+            string path = H2Ek_install_path + "data\\";
+            if (!string.IsNullOrWhiteSpace(import_lipsync_path.Text))
+            {
+                path = System.IO.Path.GetDirectoryName(import_lipsync_path.Text) + "\\";
+            }
 
             OpenFileDialog dlg = new OpenFileDialog();
             dlg.Title = "Select ltf file.";
             dlg.Filter = "Lipsync Tweak File|*.ltf";
-            if (string.IsNullOrWhiteSpace(import_lipsync_path.Text))
-            {
-                dlg.InitialDirectory = H2Ek_install_path + "data\\";
-            }
-            else
-            {
-                dlg.InitialDirectory = import_lipsync_path.Text;
-            }
+            dlg.InitialDirectory = path;
 
             if (dlg.ShowDialog() == true)
             {

--- a/Launcher/MainWindow.xaml.cs
+++ b/Launcher/MainWindow.xaml.cs
@@ -41,9 +41,7 @@ namespace Halo2CodezLauncher
         private string H2Ek_install_path = GetFolderPath(SpecialFolder.ProgramFilesX86) + "\\Microsoft Games\\Halo 2 Map Editor\\";
         private string Halo_install_path = GetFolderPath(SpecialFolder.ProgramFilesX86) + "\\Microsoft Games\\Halo 2\\";
         private string Launcher_Directory = AppDomain.CurrentDomain.BaseDirectory;
-        private string H2EK_key = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft Games\Halo 2\1.0";
         private string Guerilla_key = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Halo 2";
-        private string Tools_Install_Directory = "ToolsInstallDir";
         private string Tools_Directory = "tools_directory";
 
         [Flags]
@@ -222,12 +220,8 @@ namespace Halo2CodezLauncher
             string H2Tool_Path = AppDomain.CurrentDomain.BaseDirectory;
             if (Settings.Default.portable_install != true)
             {
-                if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair is true)
+                if (Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair is true)
                 {
-                    RegistryKey H2EK_Install_Path_key = RegistryKey
-                        .OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
-                        .CreateSubKey("SOFTWARE\\Microsoft\\Microsoft Games\\Halo 2\\1.0", true);
-
                     RegistryKey Guerilla_Tag_key = RegistryKey
                         .OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32)
                         .CreateSubKey("SOFTWARE\\Microsoft\\Halo 2", true);
@@ -252,10 +246,8 @@ namespace Halo2CodezLauncher
 
                     if (use_launcher_path != true)
                     {
-                        if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair == true)
+                        if (Registry.GetValue(Guerilla_key, Tools_Directory, null) is null || force_repair == true)
                         {
-                            H2EK_Install_Path_key.SetValue("ToolsInstallDir", H2Ek_install_path + "\\");
-                            H2EK_Install_Path_key.Close();
                             Guerilla_Tag_key.SetValue("tools_directory", H2Ek_install_path + "\\");
                             Guerilla_Tag_key.Close();
                             MessageBox.Show("Repairs completed");
@@ -298,7 +290,7 @@ namespace Halo2CodezLauncher
                 {
                     if (Settings.Default.portable_install != true)
                     {
-                        if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null)
+                        if (Registry.GetValue(Guerilla_key, Tools_Directory, null) is null)
                         {
                             if (MessageBox.Show("Is this a portable install?", "Missing Registry Keys", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                             {
@@ -318,7 +310,7 @@ namespace Halo2CodezLauncher
                         }
                     }
 
-                    if (Registry.GetValue(H2EK_key, Tools_Install_Directory, null) is null && Settings.Default.portable_install == true || Registry.GetValue(Guerilla_key, Tools_Directory, null) is null && Settings.Default.portable_install == true)
+                    if (Registry.GetValue(Guerilla_key, Tools_Directory, null) is null && Settings.Default.portable_install == true)
                     {
                         H2Ek_install_path = new FileInfo(Launcher_Directory).Directory.FullName + "\\";
                     }

--- a/Launcher/Properties/Settings.Designer.cs
+++ b/Launcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace H2CodezLauncher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -113,6 +113,18 @@ namespace H2CodezLauncher.Properties {
             }
             set {
                 this["ignore_updates"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool portable_install {
+            get {
+                return ((bool)(this["portable_install"]));
+            }
+            set {
+                this["portable_install"] = value;
             }
         }
     }

--- a/Launcher/Properties/Settings.settings
+++ b/Launcher/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="ignore_updates" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="portable_install" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Changes in this PR include

- Update, registry, and exe patch dialog boxes should no longer remain open when mainbox is closed.

- Give copyfrom the proper path if scenario is packaged from documents so that maps from the maps folder in documents get copied to our custom map folder properly.

- Start working on adding an option for portable installs. 

- Change how InitialDirectory works. If the text box is empty it will default to whatever the root folder of it's proper asset folder is. If the text box is not empty then it will use the path in there.

- import-sound command added to UI. Works by referencing a path to a .WAV or .AIFF file only. If a LTF file is also referenced then it will switch to import-lipsync and find the files properly.

Fixes #6